### PR TITLE
fix: OptionsFlow compatibility with Home Assistant 2024.x+

### DIFF
--- a/custom_components/ned_energy_forecast/config_flow.py
+++ b/custom_components/ned_energy_forecast/config_flow.py
@@ -82,15 +82,11 @@ class NEDEnergyForecastConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> NEDEnergyForecastOptionsFlow:
         """Get the options flow for this handler."""
-        return NEDEnergyForecastOptionsFlow(config_entry)
+        return NEDEnergyForecastOptionsFlow()
 
 
 class NEDEnergyForecastOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for NED Energy Forecast."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Problem

When trying to configure the integration options in Home Assistant 2024.x+, users get:

```
Config flow could not be loaded: 500 Internal Server Error Server got itself in trouble
```

The error in logs shows:
```
AttributeError: property 'config_entry' of 'NEDEnergyForecastOptionsFlow' object has no setter
```

## Root Cause

In Home Assistant 2024.x, the `OptionsFlow` base class changed `config_entry` to a **read-only property** that is automatically set by the parent class.

The previous code tried to assign `self.config_entry` in `__init__`:

```python
def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
    self.config_entry = config_entry  # ← This now raises AttributeError
```

## Fix

Remove the `__init__` method entirely and pass no arguments to `NEDEnergyForecastOptionsFlow()`. The parent class handles `config_entry` assignment automatically.

## Testing

- Verified options flow now opens correctly
- Confirmed `CONF_FORECAST_HOURS` option (12-168h range) is accessible and modifiable
- Tested on Home Assistant 2026.1.2